### PR TITLE
fix: log sync errors

### DIFF
--- a/internal/netbox/inventory/add_items.go
+++ b/internal/netbox/inventory/add_items.go
@@ -1171,6 +1171,7 @@ func (nbi *NetboxInventory) AddVM(ctx context.Context, newVM *objects.VM) (*obje
 			)
 			patchedVM, err := service.Patch[objects.VM](ctx, nbi.NetboxAPI, oldVM.ID, diffMap)
 			if err != nil {
+				nbi.Logger.Errorf(ctx, "Error while patching %s : %s", newVM.Name, err)
 				return nil, err
 			}
 			nbi.vmsIndexByNameAndClusterID[newVM.Name][newVMClusterID] = patchedVM


### PR DESCRIPTION
Log sync errors :

```sh
2025/02/26 19:46:30 add_items.go:1174   ERROR   (cluster0.corp): Error while patching foo.bar : unexpected status code: 400: {"disk":["The specified disk size (141000) must match the aggregate size of assigned virtual disks (141062)."]}
2025/02/26 19:46:30 add_items.go:1174   ERROR   (cluster0.corp): Error while patching foo.bar : unexpected status code: 400: {"disk":["The specified disk size (135000) must match the aggregate size of assigned virtual disks (135062)."]}
2025/02/26 19:46:30 add_items.go:1174   ERROR   (cluster0.corp): Error while patching foo.bar : unexpected status code: 400: {"disk":["The specified disk size (39000) must match the aggregate size of assigned virtual disks (39062)."]}
2025/02/26 19:46:30 add_items.go:1174   ERROR   (cluster0.corp): Error while patching foo.bar : unexpected status code: 400: {"disk":["The specified disk size (539000) must match the aggregate size of assigned virtual disks (539062)."]}
2025/02/26 19:46:31 add_items.go:1174   ERROR   (cluster0.corp): Error while patching foo.bar : unexpected status code: 400: {"disk":["The specified disk size (1039000) must match the aggregate size of assigned virtual disks (1039062)."]}
2025/02/26 19:46:31 add_items.go:1174   ERROR   (cluster0.corp): Error while patching foo.bar : unexpected status code: 400: {"disk":["The specified disk size (208000) must match the aggregate size of assigned virtual disks (208490)."]}
2025/02/26 19:46:31 add_items.go:1174   ERROR   (cluster0.corp): Error while patching foo.bar : unexpected status code: 400: {"disk":["The specified disk size (319000) must match the aggregate size of assigned virtual disks (319688)."]}
2025/02/26 19:46:31 add_items.go:1174   ERROR   (cluster0.corp): Error while patching foo.bar : unexpected status code: 400: {"disk":["The specified disk size (239000) must match the aggregate size of assigned virtual disks (239062)."]}
2025/02/26 19:46:31 add_items.go:1174   ERROR   (cluster0.corp): Error while patching foo.bar : unexpected status code: 400: {"disk":["The specified disk size (249000) must match the aggregate size of assigned virtual disks (249062)."]}
2025/02/26 19:46:31 add_items.go:1174   ERROR   (cluster0.corp): Error while patching foo.bar : unexpected status code: 400: {"disk":["The specified disk size (39000) must match the aggregate size of assigned virtual disks (39062)."]}
2025/02/26 19:46:31 add_items.go:1174   ERROR   (cluster0.corp): Error while patching foo.bar : unexpected status code: 400: {"disk":["The specified disk size (39000) must match the aggregate size of assigned virtual disks (39062)."]}
2025/02/26 19:46:32 add_items.go:1174   ERROR   (cluster0.corp): Error while patching foo.bar : unexpected status code: 400: {"disk":["The specified disk size (149000) must match the aggregate size of assigned virtual disks (149062)."]}
2025/02/26 19:46:32 add_items.go:1174   ERROR   (cluster0.corp): Error while patching foo.bar : unexpected status code: 400: {"disk":["The specified disk size (439000) must match the aggregate size of assigned virtual disks (439062)."]}
2025/02/26 19:46:32 add_items.go:1174   ERROR   (cluster0.corp): Error while patching foo.bar : unexpected status code: 400: {"disk":["The specified disk size (239000) must match the aggregate size of assigned virtual disks (239062)."]}
2025/02/26 19:46:32 add_items.go:1174   ERROR   (cluster0.corp): Error while patching foo.bar : unexpected status code: 400: {"disk":["The specified disk size (239000) must match the aggregate size of assigned virtual disks (239062)."]}
2025/02/26 19:46:32 add_items.go:1174   ERROR   (cluster0.corp): Error while patching foo.bar : unexpected status code: 400: {"disk":["The specified disk size (539000) must match the aggregate size of assigned virtual disks (539062)."]}
2025/02/26 19:46:33 add_items.go:1174   ERROR   (cluster0.corp): Error while patching foo.bar : unexpected status code: 400: {"disk":["The specified disk size (105000) must match the aggregate size of assigned virtual disks (105062)."]}
2025/02/26 19:46:33 add_items.go:1174   ERROR   (cluster0.corp): Error while patching foo.bar : unexpected status code: 400: {"disk":["The specified disk size (239000) must match the aggregate size of assigned virtual disks (239062)."]}
2025/02/26 19:46:33 add_items.go:1174   ERROR   (cluster0.corp): Error while patching foo.bar : unexpected status code: 400: {"disk":["The specified disk size (239000) must match the aggregate size of assigned virtual disks (239062)."]}
2025/02/26 19:46:34 add_items.go:1174   ERROR   (cluster0.corp): Error while patching foo.bar : unexpected status code: 400: {"disk":["The specified disk size (278000) must match the aggregate size of assigned virtual disks (278828)."]}
2025/02/26 19:46:34 add_items.go:1174   ERROR   (cluster0.corp): Error while patching foo.bar : unexpected status code: 400: {"disk":["The specified disk size (69000) must match the aggregate size of assigned virtual disks (69062)."]}
2025/02/26 19:46:34 add_items.go:1174   ERROR   (cluster0.corp): Error while patching foo.bar : unexpected status code: 400: {"disk":["The specified disk size (135000) must match the aggregate size of assigned virtual disks (135659)."]}
2025/02/26 19:46:34 add_items.go:1174   ERROR   (cluster0.corp): Error while patching foo.bar : unexpected status code: 400: {"disk":["The specified disk size (439000) must match the aggregate size of assigned virtual disks (439062)."]}
2025/02/26 19:46:34 add_items.go:1174   ERROR   (cluster0.corp): Error while patching foo.bar : unexpected status code: 400: {"disk":["The specified disk size (105000) must match the aggregate size of assigned virtual disks (105062)."]}
2025/02/26 19:46:34 add_items.go:1174   ERROR   (cluster0.corp): Error while patching foo.bar : unexpected status code: 400: {"disk":["The specified disk size (89000) must match the aggregate size of assigned virtual disks (89062)."]}
2025/02/26 19:46:34 add_items.go:1174   ERROR   (cluster0.corp): Error while patching foo.bar : unexpected status code: 400: {"disk":["The specified disk size (239000) must match the aggregate size of assigned virtual disks (239062)."]}
2025/02/26 19:46:35 add_items.go:1174   ERROR   (cluster0.corp): Error while patching foo.bar : unexpected status code: 400: {"disk":["The specified disk size (39000) must match the aggregate size of assigned virtual disks (39062)."]}
2025/02/26 19:46:35 add_items.go:1174   ERROR   (cluster0.corp): Error while patching foo.bar : unexpected status code: 400: {"disk":["The specified disk size (141000) must match the aggregate size of assigned virtual disks (141062)."]}
2025/02/26 19:46:35 add_items.go:1174   ERROR   (cluster0.corp): Error while patching foo.bar : unexpected status code: 400: {"disk":["The specified disk size (239000) must match the aggregate size of assigned virtual disks (239062)."]}
2025/02/26 19:46:35 add_items.go:1174   ERROR   (cluster0.corp): Error while patching foo.bar : unexpected status code: 400: {"disk":["The specified disk size (1249000) must match the aggregate size of assigned virtual disks (1249062)."]}
2025/02/26 19:46:38 add_items.go:1174   ERROR   (cluster1.corp): Error while patching foo.bar : unexpected status code: 400: {"disk":["The specified disk size (844000) must match the aggregate size of assigned virtual disks (844711)."]}
2025/02/26 19:46:39 add_items.go:1174   ERROR   (cluster2.corp): Error while patching foo.bar : unexpected status code: 400: {"disk":["The specified disk size (844000) must match the aggregate size of assigned virtual disks (844711)."]}
```

(logs have been anonymized)

Fix https://github.com/SRC-doo/netbox-ssot/issues/508

You may have a better solution.