### PR TITLE
Changed string "GB" to "GiB" for Host Memory of a Proxmox Host/Hypervisor

### DIFF
--- a/internal/source/proxmox/proxmox_sync.go
+++ b/internal/source/proxmox/proxmox_sync.go
@@ -154,7 +154,7 @@ func (ps *ProxmoxSource) syncNodes(nbi *inventory.NetboxInventory) error {
 				CustomFields: map[string]interface{}{
 					constants.CustomFieldHostCPUCoresName: fmt.Sprintf("%d", node.CPUInfo.CPUs),
 					constants.CustomFieldHostMemoryName: fmt.Sprintf(
-						"%d GB",
+						"%d GiB",
 						node.Memory.Total/constants.GiB,
 					),
 				},


### PR DESCRIPTION
When calling Proxmox, the RAM of a host is expressed in GiB, but upon host creation by SSOT the text "GB" is used in the Custom Field "Host memory". This Pull Request changes said string from "GB" to "GiB"

I have no idea how to test this change to make sure it doesn't mess with anything else. Let me know if I should do anything!